### PR TITLE
Integrate Firebase for crash reporting, analytics, and performance monitoring

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,4 +1,5 @@
 /build
 /crashlytics.properties
 /fabric.properties
+/google-services.json
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
 apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.firebase-perf'
 
 android {
     compileSdkVersion 26
@@ -152,6 +153,7 @@ dependencies {
         transitive = true
     }
     implementation 'com.google.firebase:firebase-core:16.0.7'
+    implementation 'com.google.firebase:firebase-perf:16.2.3'
     implementation "com.github.hotchemi:permissionsdispatcher:$rootProject.ext.permissionsDispatcherVersion"
     kapt "com.github.hotchemi:permissionsdispatcher-processor:$rootProject.ext.permissionsDispatcherVersion"
     implementation "com.github.slugify:slugify:2.1.9"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,6 +151,7 @@ dependencies {
     implementation("com.crashlytics.sdk.android:answers:1.3.7@aar") {
         transitive = true
     }
+    implementation 'com.google.firebase:firebase-core:16.0.7'
     implementation "com.github.hotchemi:permissionsdispatcher:$rootProject.ext.permissionsDispatcherVersion"
     kapt "com.github.hotchemi:permissionsdispatcher-processor:$rootProject.ext.permissionsDispatcherVersion"
     implementation "com.github.slugify:slugify:2.1.9"
@@ -183,3 +184,5 @@ dependencies {
     androidTestImplementation "com.android.support.test.espresso:espresso-intents:$rootProject.ext.espressoVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$rootProject.ext.espressoVersion"
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/me/vickychijwani/spectre/SpectreApplication.java
+++ b/app/src/main/java/me/vickychijwani/spectre/SpectreApplication.java
@@ -46,9 +46,6 @@ public class SpectreApplication extends Application {
     protected OkHttpClient mOkHttpClient = null;
     protected Picasso mPicasso = null;
 
-    @SuppressWarnings("FieldCanBeLocal")
-    private AnalyticsService mAnalyticsService = null;
-
     // FIXME hacks
     private LoginOrchestrator.HACKListener mHACKListener;
 
@@ -61,6 +58,7 @@ public class SpectreApplication extends Application {
         Log.i(TAG, "APP LAUNCHED");
 
         BusProvider.getBus().register(this);
+        AnalyticsService.start(this, BusProvider.getBus());
         sInstance = this;
 
         RxJavaPlugins.setErrorHandler(this::uncaughtRxException);
@@ -73,9 +71,6 @@ public class SpectreApplication extends Application {
         NetworkService networkService = new NetworkService();
         mHACKListener = networkService;
         networkService.start(mOkHttpClient);
-
-        mAnalyticsService = new AnalyticsService(BusProvider.getBus());
-        mAnalyticsService.start();
     }
 
     private void setupMetadataRealm() {

--- a/app/src/main/java/me/vickychijwani/spectre/util/BundleBuilder.kt
+++ b/app/src/main/java/me/vickychijwani/spectre/util/BundleBuilder.kt
@@ -1,0 +1,183 @@
+package me.vickychijwani.spectre.util
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.util.SparseArray
+import java.io.Serializable
+import java.util.*
+
+/**
+ * Fluent API for [android.os.Bundle]
+ * `Bundle bundle = new BundleBuilder().put(....).put(....).get();`
+ */
+class BundleBuilder {
+
+    private val bundle: Bundle = Bundle()
+
+    fun put(key: String, value: Boolean): BundleBuilder {
+        bundle.putBoolean(key, value)
+        return this
+    }
+
+    fun put(key: String, value: BooleanArray): BundleBuilder {
+        bundle.putBooleanArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Int): BundleBuilder {
+        bundle.putInt(key, value)
+        return this
+    }
+
+    fun put(key: String, value: IntArray): BundleBuilder {
+        bundle.putIntArray(key, value)
+        return this
+    }
+
+    fun putIntegerArrayList(key: String, value: ArrayList<Int>): BundleBuilder {
+        bundle.putIntegerArrayList(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Bundle): BundleBuilder {
+        bundle.putBundle(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Byte): BundleBuilder {
+        bundle.putByte(key, value)
+        return this
+    }
+
+    fun put(key: String, value: ByteArray): BundleBuilder {
+        bundle.putByteArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: String): BundleBuilder {
+        bundle.putString(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Array<String>): BundleBuilder {
+        bundle.putStringArray(key, value)
+        return this
+    }
+
+    fun putStringArrayList(key: String, value: ArrayList<String>): BundleBuilder {
+        bundle.putStringArrayList(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Long): BundleBuilder {
+        bundle.putLong(key, value)
+        return this
+    }
+
+    fun put(key: String, value: LongArray): BundleBuilder {
+        bundle.putLongArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Float): BundleBuilder {
+        bundle.putFloat(key, value)
+        return this
+    }
+
+    fun put(key: String, value: FloatArray): BundleBuilder {
+        bundle.putFloatArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Char): BundleBuilder {
+        bundle.putChar(key, value)
+        return this
+    }
+
+    fun put(key: String, value: CharArray): BundleBuilder {
+        bundle.putCharArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: CharSequence): BundleBuilder {
+        bundle.putCharSequence(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Array<CharSequence>): BundleBuilder {
+        bundle.putCharSequenceArray(key, value)
+        return this
+    }
+
+    fun putCharSequenceArrayList(key: String, value: ArrayList<CharSequence>): BundleBuilder {
+        bundle.putCharSequenceArrayList(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Double): BundleBuilder {
+        bundle.putDouble(key, value)
+        return this
+    }
+
+    fun put(key: String, value: DoubleArray): BundleBuilder {
+        bundle.putDoubleArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Parcelable): BundleBuilder {
+        bundle.putParcelable(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Array<Parcelable>): BundleBuilder {
+        bundle.putParcelableArray(key, value)
+        return this
+    }
+
+    fun putParcelableArrayList(key: String, value: ArrayList<out Parcelable>): BundleBuilder {
+        bundle.putParcelableArrayList(key, value)
+        return this
+    }
+
+    fun putSparseParcelableArray(key: String, value: SparseArray<out Parcelable>): BundleBuilder {
+        bundle.putSparseParcelableArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Short): BundleBuilder {
+        bundle.putShort(key, value)
+        return this
+    }
+
+    fun put(key: String, value: ShortArray): BundleBuilder {
+        bundle.putShortArray(key, value)
+        return this
+    }
+
+    fun put(key: String, value: Serializable): BundleBuilder {
+        bundle.putSerializable(key, value)
+        return this
+    }
+
+    fun putAll(map: Bundle): BundleBuilder {
+        bundle.putAll(map)
+        return this
+    }
+
+    /**
+     * Get the underlying bundle.
+     */
+    fun build(): Bundle {
+        return bundle
+    }
+
+    companion object {
+        /**
+         * Initialize a BundleBuilder that is copied form the given bundle. The bundle that is passed will not be modified.
+         */
+        fun copyFrom(bundle: Bundle): BundleBuilder {
+            return BundleBuilder().putAll(bundle)
+        }
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.firebase:firebase-plugins:1.1.5'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,6 +19,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
[Fabric](https://fabric.io) was acquired by Google a while ago and their tools are being merged into [Firebase](https://firebase.google.com). So we'll need to migrate off of Fabric [in the coming months](https://get.fabric.io/roadmap). Currently we use these Fabric tools:

- [Crashlytics](https://fabric.io/kits/android/crashlytics) (crash-reporting) - replaced by [Firebase Crashlytics](https://firebase.google.com/products/crashlytics/)
- [Answers](https://fabric.io/kits/android/answers) (analytics) - replaced by [Firebase Analytics](https://firebase.google.com/products/analytics/)

While we're at it, Firebase has some other nice tools for things like [performance monitoring](https://firebase.google.com/products/performance/) and [server-side app configuration](https://firebase.google.com/products/remote-config/) as well. Worth looking into those.

----

Todo:

- [x] Integrate Firebase Analytics
- [ ] Integrate Firebase Crashlytics
- [x] Integrate Firebase Performance Monitoring
- [ ] Remove all traces of Fabric

Observations:

- APK size impact with new `firebase-core` + `firebase-perf` deps: 9.86 MB -> 10.85 MB (+992 KB)
  - Removing Fabric eventually should offset this