### PR TITLE
Updated link to Ghost Blog

### DIFF
--- a/app/src/main/res/values/dont_translate.xml
+++ b/app/src/main/res/values/dont_translate.xml
@@ -24,7 +24,7 @@
     <string name="help_subtitle" translatable="false">Post in help on our forum</string>
 
     <string name="ghost_v0_error_title" translatable="false">Upgrade to Ghost 1.0</string>
-    <string name="ghost_v0_error_tip" translatable="false" tools:ignore="TypographyDashes"><![CDATA[Tap <a href="https://blog.ghost.org/1-0/#howtoupgradetoghost10">here</a> to see upgrade instructions]]></string>
+    <string name="ghost_v0_error_tip" translatable="false" tools:ignore="TypographyDashes"><![CDATA[Tap <a href="https://ghost.org/blog/1-0/#howtoupgradetoghost10">here</a> to see upgrade instructions]]></string>
     <string name="ghost_v0_error_content" translatable="false" tools:ignore="TypographyDashes"><![CDATA[You\'re using a version of Ghost older than 1.0, please upgrade. I\'ll wait for you right here.]]></string>
     <string name="ghost_v0_error_legacy" translatable="false" tools:ignore="TypographyDashes"><![CDATA[Don\'t want to upgrade now? Download the old version of %s <a href="https://play.google.com/store/apps/details?id=me.vickychijwani.spectre.legacy">here</a>]]></string>
 


### PR DESCRIPTION
blog.ghost.org moved to ghost.org/blog