### PR TITLE
Rewrite zh-HK translation

### DIFF
--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -30,8 +30,8 @@
     <string name="publish">發佈</string>
     <string name="update_post">更改文章</string>
     <string name="unpublish">未發佈</string>
-    <string name="alert_publish">要發佈草稿?</string>
-    <string name="alert_unpublish">取消發佈?</string>
+    <string name="alert_publish">要發佈草稿？</string>
+    <string name="alert_unpublish">取消發佈？</string>
     <string name="delete_draft">刪除草稿</string>
     <string name="alert_delete_draft_title">刪除此草稿？</string>
     <string name="alert_delete_draft_msg">此操作不能撤銷！</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -47,7 +47,7 @@
     <string name="discard">放棄</string>
     <string name="view_homepage">返回主頁</string>
     <string name="view_post_on_blog">在部落格中打開</string>
-    <string name="post_settings">文章設置</string>
+    <string name="post_settings">文章設定</string>
 
     <string name="save_post_progress">正在儲存文章…</string>
     <string name="save_post_failed">不能儲存文章</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -12,7 +12,7 @@
     <string name="no_such_blog">在 %s/ghost 上沒有管理頁面</string>
     <string name="login_unexpected_error">在登入過程中出現了未知錯誤，請再試一次。</string>
     <string name="login_connection_error">不能連接到 %s/ghost ，請再試一次。</string>
-    <string name="login_ssl_unsupported">您的部落格不支持 HTTPS (SSL) 連接</string>
+    <string name="login_ssl_unsupported">您的部落格不支持 HTTPS (SSL) 加密</string>
     <string name="logout">登出</string>
     <string name="credentials_expired">自動登入失敗， 請重新登入</string>
     <string name="unsynced_changes_msg">如果您現在登出，您會失去所有未同步的變更</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -112,7 +112,7 @@
     <string name="accept">接受</string>
     <string name="draft">草稿</string>
     <string name="published">已發布</string>
-    <string name="scheduled">已列入計劃</string>
+    <string name="scheduled">已排程</string>
     <string name="next">下一個</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
 
-    <string name="prompt_blog_url">部落格地址</string>
+    <string name="prompt_blog_url">部落格網址</string>
     <string name="prompt_email">電郵地址</string>
     <string name="prompt_password">密碼</string>
     <string name="action_sign_in">登入</string>
 
     <string name="error_invalid_email">這是個無效的電郵地址</string>
-    <string name="error_field_required">這是必填字段</string>
+    <string name="error_field_required">這個必須填寫</string>
 
     <string name="no_such_blog">在 %s/ghost 上沒有管理頁面</string>
     <string name="login_unexpected_error">在登入過程中出現了未知錯誤，請再試一次。</string>
@@ -66,10 +66,10 @@
     <string name="post_title_hint">文章標題</string>
     <string name="post_image_hint">添加文章圖片</string>
     <string name="post_tags_hint">標籤</string>
-    <string name="post_tags_format_hint">使用，分隔標籤</string>
+    <string name="post_tags_format_hint">使用半形逗號 , 分隔標籤</string>
     <string name="post_body_hint">開始寫你的故事…</string>
-    <string name="post_image_load_error">加載文章圖片出錯</string>
-    <string name="post_excerpt_hint">摘抄</string>
+    <string name="post_image_load_error">載入文章圖片出錯</string>
+    <string name="post_excerpt_hint">節錄</string>
     <string name="post_feature_hint">標記為特別文章</string>
     <string name="post_page_hint">發佈為靜態頁面</string>
 
@@ -86,7 +86,7 @@
     <string name="conflict_choice_use_device_copy">上傳本地副本</string>
     <string name="conflict_choice_use_server_copy">下載伺服器副本</string>
     <string name="conflict_last_update_at">最後更新於 %s</string>
-    <string name="conflict_post_preview_title">以下版本回被保留:</string>
+    <string name="conflict_post_preview_title">以下版本回被保留：</string>
     <string name="conflict_post_preview_status">文章狀態：<b>%s</b></string>
 
     <string name="about_action">關於…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -2,28 +2,28 @@
 <resources>
 
     <string name="prompt_blog_url">部落格地址</string>
-    <string name="prompt_email">電子郵箱</string>
+    <string name="prompt_email">電郵地址</string>
     <string name="prompt_password">密碼</string>
-    <string name="action_sign_in">登錄</string>
+    <string name="action_sign_in">登入</string>
 
-    <string name="error_invalid_email">這是個無效的電子郵箱</string>
+    <string name="error_invalid_email">這是個無效的電郵地址</string>
     <string name="error_field_required">這是必填字段</string>
 
     <string name="no_such_blog">在 %s/ghost 上沒有管理頁面</string>
-    <string name="login_unexpected_error">在登錄中出現了未知錯誤。請再試一次。</string>
+    <string name="login_unexpected_error">在登入過程中出現了未知錯誤，請再試一次。</string>
     <string name="login_connection_error">不能連接到 %s/ghost ，請再試一次。</string>
-    <string name="login_ssl_unsupported">您的博客不支持 HTTPS (SSL) 連接</string>
+    <string name="login_ssl_unsupported">您的部落格不支持 HTTPS (SSL) 連接</string>
     <string name="logout">登出</string>
-    <string name="credentials_expired">自動登錄失敗， 請重新登錄</string>
+    <string name="credentials_expired">自動登入失敗， 請重新登入</string>
     <string name="unsynced_changes_msg">如果您現在登出，您會失去所有未同步的變更</string>
     <string name="dont_logout">不要登出</string>
 
     <string name="status_published">發布了 %s</string>
     <string name="status_draft">草稿</string>
-    <string name="status_offline_changes">本地已保存, 等待同步到網絡…</string>
-    <string name="status_published_auto_saved">更改已保存, 暫未發佈</string>
-    <string name="status_marked_for_deletion">已標記為刪除, 等待同步到網絡…</string>
-    <string name="status_marked_for_deletion_open_error">已標記刪除, 不能被打開</string>
+    <string name="status_offline_changes">已離線儲存，等待同步到伺服器…</string>
+    <string name="status_published_auto_saved">更改已儲存，暫未發佈</string>
+    <string name="status_marked_for_deletion">已標記為刪除，等待同步到網絡…</string>
+    <string name="status_marked_for_deletion_open_error">已標記刪除，不能被打開</string>
 
     <string name="preview">預覽</string>
     <string name="edit">修改</string>
@@ -33,40 +33,40 @@
     <string name="alert_publish">要發佈草稿?</string>
     <string name="alert_unpublish">取消發佈?</string>
     <string name="delete_draft">刪除草稿</string>
-    <string name="alert_delete_draft_title">刪除此草稿?</string>
-    <string name="alert_delete_draft_msg">此操作不能撤銷!</string>
+    <string name="alert_delete_draft_title">刪除此草稿？</string>
+    <string name="alert_delete_draft_msg">此操作不能撤銷！</string>
     <string name="alert_delete_yes">刪除</string>
     <string name="alert_delete_no">保留</string>
     <string name="post_deleted">文章已被刪除</string>
-    <string name="alert_save_msg">更新文章?</string>
-    <string name="alert_save_yes">是的, 更新</string>
-    <string name="alert_save_no">暫不</string>
+    <string name="alert_save_msg">更新文章？</string>
+    <string name="alert_save_yes">更新</string>
+    <string name="alert_save_no">取消</string>
     <string name="discard_changes">放棄更改</string>
-    <string name="alert_discard_changes_title">放棄所有上一次打開以來的更改?</string>
-    <string name="alert_discard_changes_msg">這不能撤銷!</string>
+    <string name="alert_discard_changes_title">放棄所有上一次打開以來的更改？</string>
+    <string name="alert_discard_changes_msg">這不能撤銷！</string>
     <string name="discard">放棄</string>
     <string name="view_homepage">返回主頁</string>
-    <string name="view_post_on_blog">在博客中打開</string>
+    <string name="view_post_on_blog">在部落格中打開</string>
     <string name="post_settings">文章設置</string>
 
-    <string name="save_post_progress">正在保存文章…</string>
-    <string name="save_post_failed">不能保存文章</string>
-    <string name="save_post_view">在博客中查看</string>
-    <string name="save_post_timeout">已在本地設備保存</string>
+    <string name="save_post_progress">正在儲存文章…</string>
+    <string name="save_post_failed">不能儲存文章</string>
+    <string name="save_post_view">在部落格中查看</string>
+    <string name="save_post_timeout">已離線儲存</string>
 
-    <string name="save_scenario_unknown">已保存</string>
-    <string name="save_scenario_publish_draft">文章已發布!</string>
+    <string name="save_scenario_unknown">已儲存</string>
+    <string name="save_scenario_publish_draft">文章已發布！</string>
     <string name="save_scenario_unpublish_published_post">文章已取消發佈</string>
-    <string name="save_scenario_auto_save_scheduled_or_published_post">更改已在設備保存</string>
+    <string name="save_scenario_auto_save_scheduled_or_published_post">更改已離線儲存</string>
     <string name="save_scenario_explicitly_update_scheduled_or_published_post">文章已更新</string>
-    <string name="save_scenario_auto_save_draft">已保存草稿</string>
-    <string name="save_scenario_explicitly_save_draft">草稿被保存</string>
+    <string name="save_scenario_auto_save_draft">已儲存草稿</string>
+    <string name="save_scenario_explicitly_save_draft">草稿被儲存</string>
 
     <string name="status_scheduled">已發布 - %s</string>
     <string name="post_title_hint">文章標題</string>
     <string name="post_image_hint">添加文章圖片</string>
     <string name="post_tags_hint">標籤</string>
-    <string name="post_tags_format_hint">使用, 分離標籤</string>
+    <string name="post_tags_format_hint">使用，分隔標籤</string>
     <string name="post_body_hint">開始寫你的故事…</string>
     <string name="post_image_load_error">加載文章圖片出錯</string>
     <string name="post_excerpt_hint">摘抄</string>
@@ -80,35 +80,35 @@
     <string name="uploading">上傳中…</string>
     <string name="image_upload_failed">上傳圖片失敗</string>
     <string name="remove_image">刪除此圖片</string>
-    <string name="enable_permission_tip">請允許獲取您的存儲空間權限</string>
+    <string name="enable_permission_tip">請允許存取您的儲存空間權限</string>
 
-    <string name="conflict_explanation"><b>文章 <i>%s</i> 有衝突.</b> 服務端有一個更新的版本, 您需要保留哪個版本的文章?</string>
+    <string name="conflict_explanation"><b>文章 <i>%s</i> 有衝突。</b> 伺服器有一個更新的版本，您需要保留哪個版本的文章？</string>
     <string name="conflict_choice_use_device_copy">上傳本地副本</string>
-    <string name="conflict_choice_use_server_copy">下載服務端副本</string>
+    <string name="conflict_choice_use_server_copy">下載伺服器副本</string>
     <string name="conflict_last_update_at">最後更新於 %s</string>
     <string name="conflict_post_preview_title">以下版本回被保留:</string>
-    <string name="conflict_post_preview_status">文章狀態: <b>%s</b></string>
+    <string name="conflict_post_preview_status">文章狀態：<b>%s</b></string>
 
     <string name="about_action">關於…</string>
     <string name="about">關於</string>
 
     <string name="version">版本</string>
 
-    <string name="category_support_development">開發支持</string>
-    <string name="play_store">在Play Store 評論</string>
-    <string name="play_store_subtitle">謝謝您的支持!</string>
+    <string name="category_support_development">支持開發人員</string>
+    <string name="play_store">在 Play Store 評論</string>
+    <string name="play_store_subtitle">謝謝您的支持！</string>
 
     <string name="no_internet_connection">沒有網絡連接</string>
-    <string name="network_timeout">連接超時</string>
-    <string name="refresh_failed">更新數據失敗</string>
+    <string name="network_timeout">無法連接到伺服器</string>
+    <string name="refresh_failed">重新整理失敗</string>
 
     <string name="done">完成</string>
-    <string name="save">保存</string>
-    <string name="refresh">更新</string>
+    <string name="save">儲存</string>
+    <string name="refresh">重新整理</string>
     <string name="share">分享</string>
-    <string name="loading">加載中…</string>
+    <string name="loading">載入中…</string>
     <string name="insert">插入</string>
-    <string name="intent_no_apps">沒有支持此操作的應用</string>
+    <string name="intent_no_apps">沒有支持此動作的 APP</string>
     <string name="accept">接受</string>
     <string name="draft">草稿</string>
     <string name="published">已發布</string>


### PR DESCRIPTION
Due to the fact that the existing zh-HK translation is a complete myth to Hong Kong users, this PR contains a complete rewrite on grammatical, vocabulary and punctuation mistakes.